### PR TITLE
docs: make version of 约定式提交规范 unspecified

### DIFF
--- a/docs/文档贡献指南/文档贡献指南.md
+++ b/docs/文档贡献指南/文档贡献指南.md
@@ -70,7 +70,7 @@ git commit -m "docs: add new doc"
 git push
 ```
 
-注意 commit 信息需要符合[约定式提交规范](https://www.conventionalcommits.org/zh-hans/v1.0.0-beta.4/)。
+注意 commit 信息需要符合[约定式提交规范](https://www.conventionalcommits.org/zh-hans/)。
 
 ### 1.5. 发起 Pull Request
 


### PR DESCRIPTION
Remove the version of conventional commits in the link so that the link is redirected to the latest version upon clicking.